### PR TITLE
Add support for compact_bbc format

### DIFF
--- a/audio/analyzer.py
+++ b/audio/analyzer.py
@@ -218,7 +218,7 @@ def get_flac_info(file_path, upload_spectrogram=False):
         # Continues to generate spectrogram as usual
         audio_segment = AudioSegment.from_file(file_path, format="flac")
         plot_path = save_spectrogram_plot(audio_segment, file_path)
-        result['spectrogram'] = f"[url]{upload_image(plot_path)}[/url]"
+        result['spectrogram'] = f"{upload_image(plot_path)}"
 
     with open(file_path, 'rb') as flac_file:
         audio_data = flac_file.read()

--- a/format/output.py
+++ b/format/output.py
@@ -9,13 +9,21 @@ def bbcode(metadata):
 
   for track, track_info in metadata.items():
     bbcode += f"[tr]\n[td]{track}[/td]\n"
-    for value in track_info.values():
-      bbcode += f"[td]{value}[/td]\n"
+    for key, value in track_info.items():
+
+      bbcode += f"[td]"
+      if key == "spectrogram":
+        bbcode += "[url]"
+      bbcode += f"{value}"
+      if key == "spectrogram":
+        bbcode += "[/url]"
+      bbcode += "[/td]\n"
 
     bbcode += "[/tr]\n"
 
   bbcode += "[/table]"
   return bbcode
+
 
 def markdown(metadata):
     headers = ["Filename"] + [key.capitalize() for key in metadata[list(metadata.keys())[0]]]
@@ -25,7 +33,30 @@ def markdown(metadata):
     
     for track, track_info in metadata.items():
         row = [track] + list(track_info.values())
-        sanitized_row = [str(item).replace('[url]', '').replace('[/url]', '') for item in row]
-        md_table += "| " + " | ".join(sanitized_row) + " |\n"
+        md_table += "| " + " | ".join(row) + " |\n"
     
     return md_table
+
+
+def bbcode_compact(metadata):
+    # TODO: rework metadata so it contains album info instead of pulling summary info from first track.
+    # TODO: add albumartist, album, and release date to metadata for a better summary
+    first_track = list(metadata.values())[0]
+    output = (f"[size=22][b][/b][/size]\n"
+              f"[size=16]{first_track["codec"]} / {first_track["channels"]} ch / {first_track["bits_per_sample"]} bit"
+              f" / {first_track["sample_rate"]}[/size]\n\n[list=1]")
+
+    for track, track_info in metadata.items():
+        output += "[*]"
+        if track_info["embedded_cuesheet"]:
+            output += ":cd:"
+        if "spectrogram" in track_info:
+            output += f" [url={track_info["spectrogram"]}]:bar_chart:[/url]"
+
+        output += (f"{track_info["artist"]} - {track_info["title"]} / {track_info["duration"]} "
+                   f"/ {track_info["bitrate"]} / {track_info["audio_md5"]}\n")
+
+    output += ("[/list]\n\n"
+               ":cd:: indicates the track contains an embedded cuesheet.\n"
+               ":bar_chart:: indicates the track has a spectrogram for it, click the icon to view.\n")
+    return output

--- a/main.py
+++ b/main.py
@@ -21,7 +21,7 @@ def parse_args():
                         help="If the argument is provided but empty, the default album path will be used. Optionally, "
                              "provide a path to save the torrent file.")
     parser.add_argument("-c", "--config", help="Tracker configuration name.")
-    parser.add_argument("-f", "--format", choices=["bbc", "md"], default="bbc", help="Table format (bbcode/markdown).")
+    parser.add_argument("-f", "--format", choices=["bbc", "md", "compact_bbc"], default="bbc", help="Table format (bbcode/markdown).")
 
     return parser.parse_args()
 
@@ -139,7 +139,7 @@ def main():
 
 
     # Read the format_value from the user's config
-    valid_formats = ['bbc', 'md']
+    valid_formats = ['bbc', 'md', 'compact_bbc']
     output_format = format_value if format_value in valid_formats else (args.format if args.format in valid_formats else 'bbc')
 
     formatted_tables = []
@@ -147,6 +147,8 @@ def main():
     for album_meta in all_albums_meta:
         if output_format == "md":
             table_output = format.output.markdown(album_meta)
+        elif output_format == "compact_bbc":
+            table_output = format.output.bbcode_compact(album_meta)
         else:
             table_output = format.output.bbcode(album_meta)
         formatted_tables.append(table_output)


### PR DESCRIPTION
The format cleans up the amount of bbcode tags needed so that the output for most standard size albums will be less than the size of the bbc format. The more tracks on the album the more size savings you will see.

This change also removes [url][/url] wrapping around the spectrograms in the analyzer.py code so that each formatter can wrap that appropriately.

This change does not contain albumartistm, album and release date as part of the compact_bbc summary yet, there are some metadata changes needed for that.